### PR TITLE
Removes the hardcoded aws region

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -19,7 +19,6 @@ docker.enabled = true
 aws {
     accessKey =''
     secretKey =''
-    region    ='eu-west-1'
 }
 
 cloud {


### PR DESCRIPTION
With the current hardcoded aws region the pipeline cannot be run in gel production environment, that is in eu-west-2.
Hardcoded aws region is removed entirely to make possible to run pipeline both in GEL and other CloudOS environments.